### PR TITLE
Add second css property for effective gap value on the layout root level

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,11 +8,11 @@
       "sourceRange": {
         "file": "vaadin-vertical-layout.html",
         "start": {
-          "line": 125,
+          "line": 99,
           "column": 6
         },
         "end": {
-          "line": 125,
+          "line": 99,
           "column": 42
         }
       },
@@ -57,11 +57,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 109,
+              "line": 84,
               "column": 6
             },
             "end": {
-              "line": 117,
+              "line": 92,
               "column": 7
             }
           },
@@ -81,11 +81,11 @@
               "range": {
                 "file": "vaadin-horizontal-layout.html",
                 "start": {
-                  "line": 66,
+                  "line": 45,
                   "column": 6
                 },
                 "end": {
-                  "line": 66,
+                  "line": 45,
                   "column": 19
                 }
               }
@@ -136,11 +136,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 110,
+              "line": 84,
               "column": 6
             },
             "end": {
-              "line": 118,
+              "line": 92,
               "column": 7
             }
           },
@@ -160,11 +160,11 @@
               "range": {
                 "file": "vaadin-vertical-layout.html",
                 "start": {
-                  "line": 67,
+                  "line": 45,
                   "column": 6
                 },
                 "end": {
-                  "line": 67,
+                  "line": 45,
                   "column": 19
                 }
               }
@@ -176,6 +176,6962 @@
           ]
         }
       ]
+    }
+  ],
+  "elements": [
+    {
+      "description": "For internal use only",
+      "summary": "",
+      "path": "vaadin-horizontal-layout.html",
+      "properties": [
+        {
+          "name": "__serializing",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 123,
+              "column": 8
+            },
+            "end": {
+              "line": 123,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataCounter",
+          "type": "number",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1152,
+              "column": 8
+            },
+            "end": {
+              "line": 1152,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataEnabled",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 127,
+              "column": 8
+            },
+            "end": {
+              "line": 127,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 129,
+              "column": 8
+            },
+            "end": {
+              "line": 129,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataInvalid",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 131,
+              "column": 8
+            },
+            "end": {
+              "line": 131,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__data",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1134,
+              "column": 8
+            },
+            "end": {
+              "line": 1134,
+              "column": 20
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPending",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1136,
+              "column": 8
+            },
+            "end": {
+              "line": 1136,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataOld",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1138,
+              "column": 8
+            },
+            "end": {
+              "line": 1138,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataProto",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 139,
+              "column": 8
+            },
+            "end": {
+              "line": 139,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataHasAccessor",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 141,
+              "column": 8
+            },
+            "end": {
+              "line": 141,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataInstanceProps",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 143,
+              "column": 8
+            },
+            "end": {
+              "line": 143,
+              "column": 33
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataClientsReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1116,
+              "column": 8
+            },
+            "end": {
+              "line": 1116,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPendingClients",
+          "type": "Array",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1118,
+              "column": 8
+            },
+            "end": {
+              "line": 1118,
+              "column": 34
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataToNotify",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1120,
+              "column": 8
+            },
+            "end": {
+              "line": 1120,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataLinkedPaths",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1122,
+              "column": 8
+            },
+            "end": {
+              "line": 1122,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHasPaths",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1124,
+              "column": 8
+            },
+            "end": {
+              "line": 1124,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataCompoundStorage",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1126,
+              "column": 8
+            },
+            "end": {
+              "line": 1126,
+              "column": 35
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHost",
+          "type": "Polymer_PropertyEffects",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1128,
+              "column": 8
+            },
+            "end": {
+              "line": 1128,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataTemp",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1130,
+              "column": 8
+            },
+            "end": {
+              "line": 1130,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataClientsInitialized",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1132,
+              "column": 8
+            },
+            "end": {
+              "line": 1132,
+              "column": 38
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__computeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1140,
+              "column": 8
+            },
+            "end": {
+              "line": 1140,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__reflectEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1142,
+              "column": 8
+            },
+            "end": {
+              "line": 1142,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__notifyEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1144,
+              "column": 8
+            },
+            "end": {
+              "line": 1144,
+              "column": 29
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__propagateEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1146,
+              "column": 8
+            },
+            "end": {
+              "line": 1146,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__observeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1148,
+              "column": 8
+            },
+            "end": {
+              "line": 1148,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__readOnly",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1150,
+              "column": 8
+            },
+            "end": {
+              "line": 1150,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__templateInfo",
+          "type": "!TemplateInfo",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1154,
+              "column": 8
+            },
+            "end": {
+              "line": 1154,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_template",
+          "type": "HTMLTemplateElement",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 519,
+              "column": 8
+            },
+            "end": {
+              "line": 519,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 521,
+              "column": 8
+            },
+            "end": {
+              "line": 521,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "rootPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 523,
+              "column": 8
+            },
+            "end": {
+              "line": 523,
+              "column": 22
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 525,
+              "column": 8
+            },
+            "end": {
+              "line": 525,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "root",
+          "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 527,
+              "column": 8
+            },
+            "end": {
+              "line": 527,
+              "column": 18
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "$",
+          "type": "!Object.<string, !Node>",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 529,
+              "column": 8
+            },
+            "end": {
+              "line": 529,
+              "column": 15
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
+      "methods": [
+        {
+          "name": "_stampTemplate",
+          "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2320,
+              "column": 6
+            },
+            "end": {
+              "line": 2345,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to stamp"
+            }
+          ],
+          "return": {
+            "type": "!StampedTemplate",
+            "desc": "Cloned template content"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addMethodEventListenerToNode",
+          "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 451,
+              "column": 6
+            },
+            "end": {
+              "line": 456,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to add listener on"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of method"
+            },
+            {
+              "name": "context",
+              "type": "*=",
+              "description": "Context the method will be called on (defaults\n  to `node`)"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "Generated handler function"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_addEventListenerToNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 465,
+              "column": 6
+            },
+            "end": {
+              "line": 467,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to add event listener to"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "Function",
+              "description": "Listener function to add"
+            }
+          ],
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_removeEventListenerFromNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 476,
+              "column": 6
+            },
+            "end": {
+              "line": 478,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to remove event listener from"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "Function",
+              "description": "Listener function to remove"
+            }
+          ],
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "attributeChangedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`attributeChangedCallback`.\n\nBy default, attributes declared in `properties` metadata are\ndeserialized using their `type` information to properties of the\nsame name.  \"Dash-cased\" attributes are deserialized to \"camelCase\"\nproperties.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 723,
+              "column": 6
+            },
+            "end": {
+              "line": 731,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of attribute."
+            },
+            {
+              "name": "old",
+              "type": "?string",
+              "description": "Old value of attribute."
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "Current value of attribute."
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_initializeProperties",
+          "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 543,
+              "column": 6
+            },
+            "end": {
+              "line": 577,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_initializeProtoProperties",
+          "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1184,
+              "column": 6
+            },
+            "end": {
+              "line": 1188,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the prototype"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_initializeInstanceProperties",
+          "description": "Overrides `Polymer.PropertyAccessors` implementation to avoid setting\n`_setProperty`'s `shouldNotify: true`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1197,
+              "column": 6
+            },
+            "end": {
+              "line": 1206,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the instance"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_ensureAttribute",
+          "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 236,
+              "column": 6
+            },
+            "end": {
+              "line": 240,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to ensure is set."
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "of the attribute."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_attributeToProperty",
+          "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 252,
+              "column": 6
+            },
+            "end": {
+              "line": 258,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to deserialize."
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "of the attribute."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "type to deserialize to."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_propertyToAttribute",
+          "description": "Serializes a property to its associated attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 267,
+              "column": 6
+            },
+            "end": {
+              "line": 273,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name to reflect."
+            },
+            {
+              "name": "attribute",
+              "type": "string=",
+              "description": "Attribute name to reflect."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Property value to refect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_valueToNodeAttribute",
+          "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 287,
+              "column": 6
+            },
+            "end": {
+              "line": 294,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Element to set attribute to."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to serialize."
+            },
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Attribute name to serialize to."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_serializeValue",
+          "description": "Converts a typed JavaScript value to a string.\n\nThis method is called by Polymer when setting JS property values to\nHTML attributes.  Users may override this method on Polymer element\nprototypes to provide serialization for custom types.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 306,
+              "column": 6
+            },
+            "end": {
+              "line": 326,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Property value to serialize."
+            }
+          ],
+          "return": {
+            "type": "(string|undefined)",
+            "desc": "String serialized from the provided property value."
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_deserializeValue",
+          "description": "Converts a string to a typed JavaScript value.\n\nThis method is called by Polymer when reading HTML attribute values to\nJS properties.  Users may override this method on Polymer element\nprototypes to provide deserialization for custom `type`s.  Note,\nthe `type` argument is the value of the `type` field provided in the\n`properties` configuration object for a given property, and is\nby convention the constructor for the type to deserialize.\n\nNote: The return value of `undefined` is used as a sentinel value to\nindicate the attribute should be removed.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 345,
+              "column": 6
+            },
+            "end": {
+              "line": 387,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "Attribute value to deserialize."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "Type to deserialize the string to."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Typed value deserialized from the provided string."
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_createPropertyAccessor",
+          "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.  When calling on\na prototype, any overwritten values are saved in `__dataProto`,\nand it is up to the subclasser to decide how/when to set those\nproperties back into the accessor.  When calling on an instance,\nthe overwritten value is set via `_setPendingProperty`, and the\nuser should call `_invalidateProperties` or `_flushProperties`\nfor the values to take effect.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 411,
+              "column": 6
+            },
+            "end": {
+              "line": 431,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "readOnly",
+              "type": "boolean=",
+              "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_hasAccessor",
+          "description": "Returns true if this library created an accessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 439,
+              "column": 6
+            },
+            "end": {
+              "line": 441,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if an accessor was created"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_setProperty",
+          "description": "Overrides base implementation to ensure all accessors set `shouldNotify`\nto true, for per-property notification tracking.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1473,
+              "column": 6
+            },
+            "end": {
+              "line": 1477,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property"
+            },
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setPendingProperty",
+          "description": "Overrides the `PropertyAccessors` implementation to introduce special\ndirty check logic depending on the property & value being set:\n\n1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})\n   Stored in `__dataTemp`, dirty checked against `__dataTemp`\n2. Object set to simple property (e.g. 'prop': {...})\n   Stored in `__dataTemp` and `__data`, dirty checked against\n   `__dataTemp` by default implementation of `_shouldPropertyChange`\n3. Primitive value set to simple property (e.g. 'prop': 42)\n   Stored in `__data`, dirty checked against `__data`\n\nThe dirty-check is important to prevent cycles due to two-way\nnotification, but paths and objects are only dirty checked against any\nprevious value set during this turn via a \"temporary cache\" that is\ncleared when the last `_propertiesChanged` exits. This is so:\na. any cached array paths (e.g. 'array.3.prop') may be invalidated\n   due to array mutations like shift/unshift/splice; this is fine\n   since path changes are dirty-checked at user entry points like `set`\nb. dirty-checking for objects only lasts one turn to allow the user\n   to mutate the object in-place and re-set it with the same identity\n   and have all sub-properties re-propagated in a subsequent turn.\n\nThe temp cache is not necessarily sufficient to prevent invalid array\npaths, since a splice can happen during the same turn (with pathological\nuser code); we could introduce a \"fixup\" for temporarily cached array\npaths if needed: https://github.com/Polymer/polymer/issues/4227",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1436,
+              "column": 6
+            },
+            "end": {
+              "line": 1465,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "shouldNotify",
+              "type": "boolean=",
+              "description": "True if property should fire notification\n  event (applies only for `notify: true` properties)"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property changed"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_isPropertyPending",
+          "description": "Returns true if the specified property has a pending change.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 493,
+              "column": 6
+            },
+            "end": {
+              "line": 495,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if property has a pending change"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_invalidateProperties",
+          "description": "Overrides `PropertyAccessor`'s default async queuing of\n`_propertiesChanged`: if `__dataReady` is false (has not yet been\nmanually flushed), the function no-ops; otherwise flushes\n`_propertiesChanged` synchronously.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1487,
+              "column": 6
+            },
+            "end": {
+              "line": 1491,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_enableProperties",
+          "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 523,
+              "column": 6
+            },
+            "end": {
+              "line": 532,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_flushProperties",
+          "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 543,
+              "column": 6
+            },
+            "end": {
+              "line": 551,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "ready",
+          "description": "Stamps the element template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 651,
+              "column": 6
+            },
+            "end": {
+              "line": 657,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_propertiesChanged",
+          "description": "Implements `PropertyAccessors`'s properties changed callback.\n\nRuns each class of effects for the batch of changed properties in\na specific order (compute, propagate, reflect, observe, notify).",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1626,
+              "column": 6
+            },
+            "end": {
+              "line": 1659,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "currentProps"
+            },
+            {
+              "name": "changedProps"
+            },
+            {
+              "name": "oldProps"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_shouldPropertyChange",
+          "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` for primitive types if a\nstrict equality check fails, and returns `true` for all Object/Arrays.\nThe method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 606,
+              "column": 6
+            },
+            "end": {
+              "line": 609,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "New property value"
+            },
+            {
+              "name": "old",
+              "type": "*",
+              "description": "Previous property value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Whether the property should be considered a change\n  and enqueue a `_propertiesChanged` callback"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_addPropertyEffect",
+          "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1220,
+              "column": 6
+            },
+            "end": {
+              "line": 1228,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removePropertyEffect",
+          "description": "Removes the given property effect.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1237,
+              "column": 6
+            },
+            "end": {
+              "line": 1243,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property the effect was associated with"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object to remove"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasPropertyEffect",
+          "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1254,
+              "column": 6
+            },
+            "end": {
+              "line": 1257,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "type",
+              "type": "string=",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReadOnlyEffect",
+          "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1267,
+              "column": 6
+            },
+            "end": {
+              "line": 1269,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasNotifyEffect",
+          "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1279,
+              "column": 6
+            },
+            "end": {
+              "line": 1281,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReflectEffect",
+          "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1291,
+              "column": 6
+            },
+            "end": {
+              "line": 1293,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasComputedEffect",
+          "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1303,
+              "column": 6
+            },
+            "end": {
+              "line": 1305,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setPendingPropertyOrPath",
+          "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1337,
+              "column": 6
+            },
+            "end": {
+              "line": 1369,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(number|string)>)",
+              "description": "Path to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "shouldNotify",
+              "type": "boolean=",
+              "description": "Set to true if this change should\n cause a property notification event dispatch"
+            },
+            {
+              "name": "isPathNotification",
+              "type": "boolean=",
+              "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setUnmanagedPropertyToNode",
+          "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1391,
+              "column": 6
+            },
+            "end": {
+              "line": 1399,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "The node to set a property on"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "The property to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "The value to set"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_enqueueClient",
+          "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1501,
+              "column": 6
+            },
+            "end": {
+              "line": 1506,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "client",
+              "type": "Object",
+              "description": "PropertyEffects client to enqueue"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_flushClients",
+          "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1514,
+              "column": 6
+            },
+            "end": {
+              "line": 1525,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__enableOrFlushClients",
+          "description": "(c) the stamped dom enables.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1539,
+              "column": 6
+            },
+            "end": {
+              "line": 1552,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_readyClients",
+          "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 668,
+              "column": 6
+            },
+            "end": {
+              "line": 677,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "setProperties",
+          "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1579,
+              "column": 6
+            },
+            "end": {
+              "line": 1590,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+            },
+            {
+              "name": "setReadOnly",
+              "type": "boolean=",
+              "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_propagatePropertyChanges",
+          "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1670,
+              "column": 6
+            },
+            "end": {
+              "line": 1680,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changedProps",
+              "type": "Object",
+              "description": "Bag of changed properties"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "linkPaths",
+          "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1690,
+              "column": 6
+            },
+            "end": {
+              "line": 1695,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "to",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Target path to link."
+            },
+            {
+              "name": "from",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Source path to link."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unlinkPaths",
+          "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1706,
+              "column": 6
+            },
+            "end": {
+              "line": 1711,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Target path to unlink."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifySplices",
+          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1742,
+              "column": 6
+            },
+            "end": {
+              "line": 1746,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "splices",
+              "type": "Array",
+              "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "get",
+          "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1767,
+              "column": 6
+            },
+            "end": {
+              "line": 1769,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "set",
+          "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1791,
+              "column": 6
+            },
+            "end": {
+              "line": 1801,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set at the specified path."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "push",
+          "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1817,
+              "column": 6
+            },
+            "end": {
+              "line": 1826,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "...items"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "pop",
+          "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1841,
+              "column": 6
+            },
+            "end": {
+              "line": 1850,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "splice",
+          "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1869,
+              "column": 6
+            },
+            "end": {
+              "line": 1886,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "start",
+              "type": "number",
+              "description": "Index from which to start removing/inserting."
+            },
+            {
+              "name": "deleteCount",
+              "type": "number",
+              "description": "Number of items to remove."
+            },
+            {
+              "name": "...items"
+            }
+          ],
+          "return": {
+            "type": "Array",
+            "desc": "Array of removed items."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "shift",
+          "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1901,
+              "column": 6
+            },
+            "end": {
+              "line": 1910,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unshift",
+          "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1926,
+              "column": 6
+            },
+            "end": {
+              "line": 1934,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "...items"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifyPath",
+          "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1948,
+              "column": 6
+            },
+            "end": {
+              "line": 1965,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Value at the path (optional)."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReadOnlyProperty",
+          "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1977,
+              "column": 6
+            },
+            "end": {
+              "line": 1984,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createPropertyObserver",
+          "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1997,
+              "column": 6
+            },
+            "end": {
+              "line": 2007,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createMethodObserver",
+          "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2019,
+              "column": 6
+            },
+            "end": {
+              "line": 2025,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createNotifyingProperty",
+          "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2035,
+              "column": 6
+            },
+            "end": {
+              "line": 2043,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReflectedProperty",
+          "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2053,
+              "column": 6
+            },
+            "end": {
+              "line": 2066,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createComputedProperty",
+          "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2079,
+              "column": 6
+            },
+            "end": {
+              "line": 2085,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_bindTemplate",
+          "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2255,
+              "column": 6
+            },
+            "end": {
+              "line": 2278,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            },
+            {
+              "name": "instanceBinding",
+              "type": "boolean=",
+              "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removeBoundDom",
+          "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2355,
+              "column": 6
+            },
+            "end": {
+              "line": 2376,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "!StampedTemplate",
+              "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "connectedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 633,
+              "column": 6
+            },
+            "end": {
+              "line": 638,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`disconnectedCallback`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 644,
+              "column": 6
+            },
+            "end": {
+              "line": 644,
+              "column": 31
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_attachDom",
+          "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 691,
+              "column": 6
+            },
+            "end": {
+              "line": 707,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "StampedTemplate",
+              "description": "to attach to the element."
+            }
+          ],
+          "return": {
+            "type": "ShadowRoot",
+            "desc": "node to which the dom has been attached."
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "updateStyles",
+          "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 750,
+              "column": 6
+            },
+            "end": {
+              "line": 754,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "properties",
+              "type": "Object=",
+              "description": "Bag of custom property key/values to\n  apply to this element."
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "resolveUrl",
+          "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 767,
+              "column": 6
+            },
+            "end": {
+              "line": 772,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "url",
+              "type": "string",
+              "description": "URL to resolve."
+            },
+            {
+              "name": "base",
+              "type": "string=",
+              "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Rewritten URL relative to base"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
+      "staticMethods": [
+        {
+          "name": "_parseTemplate",
+          "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 197,
+              "column": 6
+            },
+            "end": {
+              "line": 208,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to parse"
+            },
+            {
+              "name": "outerTemplateInfo",
+              "type": "TemplateInfo=",
+              "description": "Template metadata from the outer\n  template, for parsing nested templates"
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Parsed template metadata"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateContent",
+          "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 783,
+              "column": 6
+            },
+            "end": {
+              "line": 786,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template"
+            },
+            {
+              "name": "templateInfo"
+            },
+            {
+              "name": "nodeInfo"
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_parseTemplateNode",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2395,
+              "column": 6
+            },
+            "end": {
+              "line": 2409,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateChildNodes",
+          "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 257,
+              "column": 6
+            },
+            "end": {
+              "line": 294,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "root",
+              "type": "Node",
+              "description": "Root node whose `childNodes` will be parsed"
+            },
+            {
+              "name": "templateInfo",
+              "type": "!TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "!NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNestedTemplate",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2482,
+              "column": 6
+            },
+            "end": {
+              "line": 2492,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateNodeAttributes",
+          "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 332,
+              "column": 6
+            },
+            "end": {
+              "line": 341,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNodeAttribute",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2430,
+              "column": 6
+            },
+            "end": {
+              "line": 2466,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Attribute name"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "Attribute value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_contentForTemplate",
+          "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 387,
+              "column": 6
+            },
+            "end": {
+              "line": 390,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template to retrieve `content` for"
+            }
+          ],
+          "return": {
+            "type": "DocumentFragment",
+            "desc": "Content fragment"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "createPropertiesForAttributes",
+          "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 113,
+              "column": 6
+            },
+            "end": {
+              "line": 118,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "addPropertyEffect",
+          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2124,
+              "column": 6
+            },
+            "end": {
+              "line": 2126,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createPropertyObserver",
+          "description": "Creates a single-property observer for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2137,
+              "column": 6
+            },
+            "end": {
+              "line": 2139,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createMethodObserver",
+          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2153,
+              "column": 6
+            },
+            "end": {
+              "line": 2155,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createNotifyingProperty",
+          "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2164,
+              "column": 6
+            },
+            "end": {
+              "line": 2166,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReadOnlyProperty",
+          "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2183,
+              "column": 6
+            },
+            "end": {
+              "line": 2185,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReflectedProperty",
+          "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2194,
+              "column": 6
+            },
+            "end": {
+              "line": 2196,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createComputedProperty",
+          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2211,
+              "column": 6
+            },
+            "end": {
+              "line": 2213,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "bindTemplate",
+          "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2227,
+              "column": 6
+            },
+            "end": {
+              "line": 2229,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "Template metadata object"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addTemplatePropertyEffect",
+          "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2292,
+              "column": 6
+            },
+            "end": {
+              "line": 2298,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Template metadata to add effect to"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseBindings",
+          "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2527,
+              "column": 6
+            },
+            "end": {
+              "line": 2592,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "text",
+              "type": "string",
+              "description": "Text to parse from attribute or textContent"
+            },
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Current template metadata"
+            }
+          ],
+          "return": {
+            "type": "Array.<!BindingPart>",
+            "desc": "Array of binding part metadata"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_evaluateBinding",
+          "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2608,
+              "column": 6
+            },
+            "end": {
+              "line": 2625,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "inst",
+              "type": "this",
+              "description": "Element that should be used as scope for\n  binding dependencies"
+            },
+            {
+              "name": "part",
+              "type": "BindingPart",
+              "description": "Binding part metadata"
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Property/path that triggered this effect"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of current property changes"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value the binding part evaluated to"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "finalize",
+          "description": "Called automatically when the first element instance is created to\nensure that class finalization work has been completed.\nMay be called by users to eagerly perform class finalization work\nprior to the creation of the first element instance.\n\nClass finalization work generally includes meta-programming such as\ncreating property accessors and any property effect metadata needed for\nthe features used.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 441,
+              "column": 6
+            },
+            "end": {
+              "line": 445,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_processStyleText",
+          "description": "Gather style text for the template",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 588,
+              "column": 6
+            },
+            "end": {
+              "line": 591,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name for this element"
+            },
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to process"
+            },
+            {
+              "name": "baseURI",
+              "type": "string",
+              "description": "Base URI to rebase CSS paths against"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "The combined CSS text"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_finalizeTemplate",
+          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 602,
+              "column": 6
+            },
+            "end": {
+              "line": 621,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name (or type extension name) for this element"
+            },
+            {
+              "name": "ext",
+              "type": "string=",
+              "description": "For type extensions, the tag name that was extended"
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 138,
+          "column": 6
+        },
+        "end": {
+          "line": 142,
+          "column": 7
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "name": "VaadinHorizontalLayoutContainer",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "vaadin-horizontal-layout.html",
+            "start": {
+              "line": 131,
+              "column": 4
+            },
+            "end": {
+              "line": 131,
+              "column": 17
+            }
+          }
+        }
+      ],
+      "tagname": "vaadin-horizontal-layout-container"
+    },
+    {
+      "description": "For internal use only",
+      "summary": "",
+      "path": "vaadin-vertical-layout.html",
+      "properties": [
+        {
+          "name": "__serializing",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 123,
+              "column": 8
+            },
+            "end": {
+              "line": 123,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataCounter",
+          "type": "number",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1152,
+              "column": 8
+            },
+            "end": {
+              "line": 1152,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataEnabled",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 127,
+              "column": 8
+            },
+            "end": {
+              "line": 127,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 129,
+              "column": 8
+            },
+            "end": {
+              "line": 129,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataInvalid",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 131,
+              "column": 8
+            },
+            "end": {
+              "line": 131,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__data",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1134,
+              "column": 8
+            },
+            "end": {
+              "line": 1134,
+              "column": 20
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPending",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1136,
+              "column": 8
+            },
+            "end": {
+              "line": 1136,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataOld",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1138,
+              "column": 8
+            },
+            "end": {
+              "line": 1138,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataProto",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 139,
+              "column": 8
+            },
+            "end": {
+              "line": 139,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataHasAccessor",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 141,
+              "column": 8
+            },
+            "end": {
+              "line": 141,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataInstanceProps",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 143,
+              "column": 8
+            },
+            "end": {
+              "line": 143,
+              "column": 33
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataClientsReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1116,
+              "column": 8
+            },
+            "end": {
+              "line": 1116,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPendingClients",
+          "type": "Array",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1118,
+              "column": 8
+            },
+            "end": {
+              "line": 1118,
+              "column": 34
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataToNotify",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1120,
+              "column": 8
+            },
+            "end": {
+              "line": 1120,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataLinkedPaths",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1122,
+              "column": 8
+            },
+            "end": {
+              "line": 1122,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHasPaths",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1124,
+              "column": 8
+            },
+            "end": {
+              "line": 1124,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataCompoundStorage",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1126,
+              "column": 8
+            },
+            "end": {
+              "line": 1126,
+              "column": 35
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHost",
+          "type": "Polymer_PropertyEffects",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1128,
+              "column": 8
+            },
+            "end": {
+              "line": 1128,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataTemp",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1130,
+              "column": 8
+            },
+            "end": {
+              "line": 1130,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataClientsInitialized",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1132,
+              "column": 8
+            },
+            "end": {
+              "line": 1132,
+              "column": 38
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__computeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1140,
+              "column": 8
+            },
+            "end": {
+              "line": 1140,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__reflectEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1142,
+              "column": 8
+            },
+            "end": {
+              "line": 1142,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__notifyEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1144,
+              "column": 8
+            },
+            "end": {
+              "line": 1144,
+              "column": 29
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__propagateEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1146,
+              "column": 8
+            },
+            "end": {
+              "line": 1146,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__observeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1148,
+              "column": 8
+            },
+            "end": {
+              "line": 1148,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__readOnly",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1150,
+              "column": 8
+            },
+            "end": {
+              "line": 1150,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__templateInfo",
+          "type": "!TemplateInfo",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1154,
+              "column": 8
+            },
+            "end": {
+              "line": 1154,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_template",
+          "type": "HTMLTemplateElement",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 519,
+              "column": 8
+            },
+            "end": {
+              "line": 519,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 521,
+              "column": 8
+            },
+            "end": {
+              "line": 521,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "rootPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 523,
+              "column": 8
+            },
+            "end": {
+              "line": 523,
+              "column": 22
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 525,
+              "column": 8
+            },
+            "end": {
+              "line": 525,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "root",
+          "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 527,
+              "column": 8
+            },
+            "end": {
+              "line": 527,
+              "column": 18
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "$",
+          "type": "!Object.<string, !Node>",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 529,
+              "column": 8
+            },
+            "end": {
+              "line": 529,
+              "column": 15
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
+      "methods": [
+        {
+          "name": "_stampTemplate",
+          "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2320,
+              "column": 6
+            },
+            "end": {
+              "line": 2345,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to stamp"
+            }
+          ],
+          "return": {
+            "type": "!StampedTemplate",
+            "desc": "Cloned template content"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addMethodEventListenerToNode",
+          "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 451,
+              "column": 6
+            },
+            "end": {
+              "line": 456,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to add listener on"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of method"
+            },
+            {
+              "name": "context",
+              "type": "*=",
+              "description": "Context the method will be called on (defaults\n  to `node`)"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "Generated handler function"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_addEventListenerToNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 465,
+              "column": 6
+            },
+            "end": {
+              "line": 467,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to add event listener to"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "Function",
+              "description": "Listener function to add"
+            }
+          ],
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_removeEventListenerFromNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 476,
+              "column": 6
+            },
+            "end": {
+              "line": 478,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to remove event listener from"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "Function",
+              "description": "Listener function to remove"
+            }
+          ],
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "attributeChangedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`attributeChangedCallback`.\n\nBy default, attributes declared in `properties` metadata are\ndeserialized using their `type` information to properties of the\nsame name.  \"Dash-cased\" attributes are deserialized to \"camelCase\"\nproperties.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 723,
+              "column": 6
+            },
+            "end": {
+              "line": 731,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of attribute."
+            },
+            {
+              "name": "old",
+              "type": "?string",
+              "description": "Old value of attribute."
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "Current value of attribute."
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_initializeProperties",
+          "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 543,
+              "column": 6
+            },
+            "end": {
+              "line": 577,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_initializeProtoProperties",
+          "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1184,
+              "column": 6
+            },
+            "end": {
+              "line": 1188,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the prototype"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_initializeInstanceProperties",
+          "description": "Overrides `Polymer.PropertyAccessors` implementation to avoid setting\n`_setProperty`'s `shouldNotify: true`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1197,
+              "column": 6
+            },
+            "end": {
+              "line": 1206,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the instance"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_ensureAttribute",
+          "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 236,
+              "column": 6
+            },
+            "end": {
+              "line": 240,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to ensure is set."
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "of the attribute."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_attributeToProperty",
+          "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 252,
+              "column": 6
+            },
+            "end": {
+              "line": 258,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to deserialize."
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "of the attribute."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "type to deserialize to."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_propertyToAttribute",
+          "description": "Serializes a property to its associated attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 267,
+              "column": 6
+            },
+            "end": {
+              "line": 273,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name to reflect."
+            },
+            {
+              "name": "attribute",
+              "type": "string=",
+              "description": "Attribute name to reflect."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Property value to refect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_valueToNodeAttribute",
+          "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 287,
+              "column": 6
+            },
+            "end": {
+              "line": 294,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Element to set attribute to."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to serialize."
+            },
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Attribute name to serialize to."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_serializeValue",
+          "description": "Converts a typed JavaScript value to a string.\n\nThis method is called by Polymer when setting JS property values to\nHTML attributes.  Users may override this method on Polymer element\nprototypes to provide serialization for custom types.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 306,
+              "column": 6
+            },
+            "end": {
+              "line": 326,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Property value to serialize."
+            }
+          ],
+          "return": {
+            "type": "(string|undefined)",
+            "desc": "String serialized from the provided property value."
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_deserializeValue",
+          "description": "Converts a string to a typed JavaScript value.\n\nThis method is called by Polymer when reading HTML attribute values to\nJS properties.  Users may override this method on Polymer element\nprototypes to provide deserialization for custom `type`s.  Note,\nthe `type` argument is the value of the `type` field provided in the\n`properties` configuration object for a given property, and is\nby convention the constructor for the type to deserialize.\n\nNote: The return value of `undefined` is used as a sentinel value to\nindicate the attribute should be removed.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 345,
+              "column": 6
+            },
+            "end": {
+              "line": 387,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "Attribute value to deserialize."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "Type to deserialize the string to."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Typed value deserialized from the provided string."
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_createPropertyAccessor",
+          "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.  When calling on\na prototype, any overwritten values are saved in `__dataProto`,\nand it is up to the subclasser to decide how/when to set those\nproperties back into the accessor.  When calling on an instance,\nthe overwritten value is set via `_setPendingProperty`, and the\nuser should call `_invalidateProperties` or `_flushProperties`\nfor the values to take effect.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 411,
+              "column": 6
+            },
+            "end": {
+              "line": 431,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "readOnly",
+              "type": "boolean=",
+              "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_hasAccessor",
+          "description": "Returns true if this library created an accessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 439,
+              "column": 6
+            },
+            "end": {
+              "line": 441,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if an accessor was created"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_setProperty",
+          "description": "Overrides base implementation to ensure all accessors set `shouldNotify`\nto true, for per-property notification tracking.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1473,
+              "column": 6
+            },
+            "end": {
+              "line": 1477,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property"
+            },
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setPendingProperty",
+          "description": "Overrides the `PropertyAccessors` implementation to introduce special\ndirty check logic depending on the property & value being set:\n\n1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})\n   Stored in `__dataTemp`, dirty checked against `__dataTemp`\n2. Object set to simple property (e.g. 'prop': {...})\n   Stored in `__dataTemp` and `__data`, dirty checked against\n   `__dataTemp` by default implementation of `_shouldPropertyChange`\n3. Primitive value set to simple property (e.g. 'prop': 42)\n   Stored in `__data`, dirty checked against `__data`\n\nThe dirty-check is important to prevent cycles due to two-way\nnotification, but paths and objects are only dirty checked against any\nprevious value set during this turn via a \"temporary cache\" that is\ncleared when the last `_propertiesChanged` exits. This is so:\na. any cached array paths (e.g. 'array.3.prop') may be invalidated\n   due to array mutations like shift/unshift/splice; this is fine\n   since path changes are dirty-checked at user entry points like `set`\nb. dirty-checking for objects only lasts one turn to allow the user\n   to mutate the object in-place and re-set it with the same identity\n   and have all sub-properties re-propagated in a subsequent turn.\n\nThe temp cache is not necessarily sufficient to prevent invalid array\npaths, since a splice can happen during the same turn (with pathological\nuser code); we could introduce a \"fixup\" for temporarily cached array\npaths if needed: https://github.com/Polymer/polymer/issues/4227",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1436,
+              "column": 6
+            },
+            "end": {
+              "line": 1465,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "shouldNotify",
+              "type": "boolean=",
+              "description": "True if property should fire notification\n  event (applies only for `notify: true` properties)"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property changed"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_isPropertyPending",
+          "description": "Returns true if the specified property has a pending change.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 493,
+              "column": 6
+            },
+            "end": {
+              "line": 495,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if property has a pending change"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_invalidateProperties",
+          "description": "Overrides `PropertyAccessor`'s default async queuing of\n`_propertiesChanged`: if `__dataReady` is false (has not yet been\nmanually flushed), the function no-ops; otherwise flushes\n`_propertiesChanged` synchronously.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1487,
+              "column": 6
+            },
+            "end": {
+              "line": 1491,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_enableProperties",
+          "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 523,
+              "column": 6
+            },
+            "end": {
+              "line": 532,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_flushProperties",
+          "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 543,
+              "column": 6
+            },
+            "end": {
+              "line": 551,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "ready",
+          "description": "Stamps the element template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 651,
+              "column": 6
+            },
+            "end": {
+              "line": 657,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_propertiesChanged",
+          "description": "Implements `PropertyAccessors`'s properties changed callback.\n\nRuns each class of effects for the batch of changed properties in\na specific order (compute, propagate, reflect, observe, notify).",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1626,
+              "column": 6
+            },
+            "end": {
+              "line": 1659,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "currentProps"
+            },
+            {
+              "name": "changedProps"
+            },
+            {
+              "name": "oldProps"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_shouldPropertyChange",
+          "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` for primitive types if a\nstrict equality check fails, and returns `true` for all Object/Arrays.\nThe method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 606,
+              "column": 6
+            },
+            "end": {
+              "line": 609,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "New property value"
+            },
+            {
+              "name": "old",
+              "type": "*",
+              "description": "Previous property value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Whether the property should be considered a change\n  and enqueue a `_propertiesChanged` callback"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_addPropertyEffect",
+          "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1220,
+              "column": 6
+            },
+            "end": {
+              "line": 1228,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removePropertyEffect",
+          "description": "Removes the given property effect.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1237,
+              "column": 6
+            },
+            "end": {
+              "line": 1243,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property the effect was associated with"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object to remove"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasPropertyEffect",
+          "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1254,
+              "column": 6
+            },
+            "end": {
+              "line": 1257,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "type",
+              "type": "string=",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReadOnlyEffect",
+          "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1267,
+              "column": 6
+            },
+            "end": {
+              "line": 1269,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasNotifyEffect",
+          "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1279,
+              "column": 6
+            },
+            "end": {
+              "line": 1281,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReflectEffect",
+          "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1291,
+              "column": 6
+            },
+            "end": {
+              "line": 1293,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasComputedEffect",
+          "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1303,
+              "column": 6
+            },
+            "end": {
+              "line": 1305,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setPendingPropertyOrPath",
+          "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1337,
+              "column": 6
+            },
+            "end": {
+              "line": 1369,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(number|string)>)",
+              "description": "Path to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "shouldNotify",
+              "type": "boolean=",
+              "description": "Set to true if this change should\n cause a property notification event dispatch"
+            },
+            {
+              "name": "isPathNotification",
+              "type": "boolean=",
+              "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setUnmanagedPropertyToNode",
+          "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1391,
+              "column": 6
+            },
+            "end": {
+              "line": 1399,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "The node to set a property on"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "The property to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "The value to set"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_enqueueClient",
+          "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1501,
+              "column": 6
+            },
+            "end": {
+              "line": 1506,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "client",
+              "type": "Object",
+              "description": "PropertyEffects client to enqueue"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_flushClients",
+          "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1514,
+              "column": 6
+            },
+            "end": {
+              "line": 1525,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__enableOrFlushClients",
+          "description": "(c) the stamped dom enables.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1539,
+              "column": 6
+            },
+            "end": {
+              "line": 1552,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_readyClients",
+          "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 668,
+              "column": 6
+            },
+            "end": {
+              "line": 677,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "setProperties",
+          "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1579,
+              "column": 6
+            },
+            "end": {
+              "line": 1590,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+            },
+            {
+              "name": "setReadOnly",
+              "type": "boolean=",
+              "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_propagatePropertyChanges",
+          "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1670,
+              "column": 6
+            },
+            "end": {
+              "line": 1680,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changedProps",
+              "type": "Object",
+              "description": "Bag of changed properties"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "linkPaths",
+          "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1690,
+              "column": 6
+            },
+            "end": {
+              "line": 1695,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "to",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Target path to link."
+            },
+            {
+              "name": "from",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Source path to link."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unlinkPaths",
+          "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1706,
+              "column": 6
+            },
+            "end": {
+              "line": 1711,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Target path to unlink."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifySplices",
+          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1742,
+              "column": 6
+            },
+            "end": {
+              "line": 1746,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "splices",
+              "type": "Array",
+              "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "get",
+          "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1767,
+              "column": 6
+            },
+            "end": {
+              "line": 1769,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "set",
+          "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1791,
+              "column": 6
+            },
+            "end": {
+              "line": 1801,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set at the specified path."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "push",
+          "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1817,
+              "column": 6
+            },
+            "end": {
+              "line": 1826,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "...items"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "pop",
+          "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1841,
+              "column": 6
+            },
+            "end": {
+              "line": 1850,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "splice",
+          "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1869,
+              "column": 6
+            },
+            "end": {
+              "line": 1886,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "start",
+              "type": "number",
+              "description": "Index from which to start removing/inserting."
+            },
+            {
+              "name": "deleteCount",
+              "type": "number",
+              "description": "Number of items to remove."
+            },
+            {
+              "name": "...items"
+            }
+          ],
+          "return": {
+            "type": "Array",
+            "desc": "Array of removed items."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "shift",
+          "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1901,
+              "column": 6
+            },
+            "end": {
+              "line": 1910,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unshift",
+          "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1926,
+              "column": 6
+            },
+            "end": {
+              "line": 1934,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "...items"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifyPath",
+          "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1948,
+              "column": 6
+            },
+            "end": {
+              "line": 1965,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Value at the path (optional)."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReadOnlyProperty",
+          "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1977,
+              "column": 6
+            },
+            "end": {
+              "line": 1984,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createPropertyObserver",
+          "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1997,
+              "column": 6
+            },
+            "end": {
+              "line": 2007,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createMethodObserver",
+          "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2019,
+              "column": 6
+            },
+            "end": {
+              "line": 2025,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createNotifyingProperty",
+          "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2035,
+              "column": 6
+            },
+            "end": {
+              "line": 2043,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReflectedProperty",
+          "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2053,
+              "column": 6
+            },
+            "end": {
+              "line": 2066,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createComputedProperty",
+          "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2079,
+              "column": 6
+            },
+            "end": {
+              "line": 2085,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_bindTemplate",
+          "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2255,
+              "column": 6
+            },
+            "end": {
+              "line": 2278,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            },
+            {
+              "name": "instanceBinding",
+              "type": "boolean=",
+              "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removeBoundDom",
+          "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2355,
+              "column": 6
+            },
+            "end": {
+              "line": 2376,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "!StampedTemplate",
+              "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "connectedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 633,
+              "column": 6
+            },
+            "end": {
+              "line": 638,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`disconnectedCallback`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 644,
+              "column": 6
+            },
+            "end": {
+              "line": 644,
+              "column": 31
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_attachDom",
+          "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 691,
+              "column": 6
+            },
+            "end": {
+              "line": 707,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "StampedTemplate",
+              "description": "to attach to the element."
+            }
+          ],
+          "return": {
+            "type": "ShadowRoot",
+            "desc": "node to which the dom has been attached."
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "updateStyles",
+          "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 750,
+              "column": 6
+            },
+            "end": {
+              "line": 754,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "properties",
+              "type": "Object=",
+              "description": "Bag of custom property key/values to\n  apply to this element."
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "resolveUrl",
+          "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 767,
+              "column": 6
+            },
+            "end": {
+              "line": 772,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "url",
+              "type": "string",
+              "description": "URL to resolve."
+            },
+            {
+              "name": "base",
+              "type": "string=",
+              "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Rewritten URL relative to base"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
+      "staticMethods": [
+        {
+          "name": "_parseTemplate",
+          "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 197,
+              "column": 6
+            },
+            "end": {
+              "line": 208,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to parse"
+            },
+            {
+              "name": "outerTemplateInfo",
+              "type": "TemplateInfo=",
+              "description": "Template metadata from the outer\n  template, for parsing nested templates"
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Parsed template metadata"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateContent",
+          "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 783,
+              "column": 6
+            },
+            "end": {
+              "line": 786,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template"
+            },
+            {
+              "name": "templateInfo"
+            },
+            {
+              "name": "nodeInfo"
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_parseTemplateNode",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2395,
+              "column": 6
+            },
+            "end": {
+              "line": 2409,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateChildNodes",
+          "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 257,
+              "column": 6
+            },
+            "end": {
+              "line": 294,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "root",
+              "type": "Node",
+              "description": "Root node whose `childNodes` will be parsed"
+            },
+            {
+              "name": "templateInfo",
+              "type": "!TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "!NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNestedTemplate",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2482,
+              "column": 6
+            },
+            "end": {
+              "line": 2492,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateNodeAttributes",
+          "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 332,
+              "column": 6
+            },
+            "end": {
+              "line": 341,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNodeAttribute",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2430,
+              "column": 6
+            },
+            "end": {
+              "line": 2466,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Attribute name"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "Attribute value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_contentForTemplate",
+          "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 387,
+              "column": 6
+            },
+            "end": {
+              "line": 390,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template to retrieve `content` for"
+            }
+          ],
+          "return": {
+            "type": "DocumentFragment",
+            "desc": "Content fragment"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "createPropertiesForAttributes",
+          "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 113,
+              "column": 6
+            },
+            "end": {
+              "line": 118,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "addPropertyEffect",
+          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2124,
+              "column": 6
+            },
+            "end": {
+              "line": 2126,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createPropertyObserver",
+          "description": "Creates a single-property observer for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2137,
+              "column": 6
+            },
+            "end": {
+              "line": 2139,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createMethodObserver",
+          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2153,
+              "column": 6
+            },
+            "end": {
+              "line": 2155,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createNotifyingProperty",
+          "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2164,
+              "column": 6
+            },
+            "end": {
+              "line": 2166,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReadOnlyProperty",
+          "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2183,
+              "column": 6
+            },
+            "end": {
+              "line": 2185,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReflectedProperty",
+          "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2194,
+              "column": 6
+            },
+            "end": {
+              "line": 2196,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createComputedProperty",
+          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2211,
+              "column": 6
+            },
+            "end": {
+              "line": 2213,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "bindTemplate",
+          "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2227,
+              "column": 6
+            },
+            "end": {
+              "line": 2229,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "Template metadata object"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addTemplatePropertyEffect",
+          "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2292,
+              "column": 6
+            },
+            "end": {
+              "line": 2298,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Template metadata to add effect to"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseBindings",
+          "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2527,
+              "column": 6
+            },
+            "end": {
+              "line": 2592,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "text",
+              "type": "string",
+              "description": "Text to parse from attribute or textContent"
+            },
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Current template metadata"
+            }
+          ],
+          "return": {
+            "type": "Array.<!BindingPart>",
+            "desc": "Array of binding part metadata"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_evaluateBinding",
+          "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2608,
+              "column": 6
+            },
+            "end": {
+              "line": 2625,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "inst",
+              "type": "this",
+              "description": "Element that should be used as scope for\n  binding dependencies"
+            },
+            {
+              "name": "part",
+              "type": "BindingPart",
+              "description": "Binding part metadata"
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Property/path that triggered this effect"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of current property changes"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value the binding part evaluated to"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "finalize",
+          "description": "Called automatically when the first element instance is created to\nensure that class finalization work has been completed.\nMay be called by users to eagerly perform class finalization work\nprior to the creation of the first element instance.\n\nClass finalization work generally includes meta-programming such as\ncreating property accessors and any property effect metadata needed for\nthe features used.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 441,
+              "column": 6
+            },
+            "end": {
+              "line": 445,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_processStyleText",
+          "description": "Gather style text for the template",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 588,
+              "column": 6
+            },
+            "end": {
+              "line": 591,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name for this element"
+            },
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to process"
+            },
+            {
+              "name": "baseURI",
+              "type": "string",
+              "description": "Base URI to rebase CSS paths against"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "The combined CSS text"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_finalizeTemplate",
+          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 602,
+              "column": 6
+            },
+            "end": {
+              "line": 621,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name (or type extension name) for this element"
+            },
+            {
+              "name": "ext",
+              "type": "string=",
+              "description": "For type extensions, the tag name that was extended"
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 139,
+          "column": 6
+        },
+        "end": {
+          "line": 143,
+          "column": 7
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "name": "VaadinVerticalLayoutContainer",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "vaadin-vertical-layout.html",
+            "start": {
+              "line": 132,
+              "column": 4
+            },
+            "end": {
+              "line": 132,
+              "column": 17
+            }
+          }
+        }
+      ],
+      "tagname": "vaadin-vertical-layout-container"
     }
   ]
 }

--- a/test/horizontal-layout.html
+++ b/test/horizontal-layout.html
@@ -31,6 +31,17 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="nested">
+    <template>
+      <vaadin-horizontal-layout id="container">
+        <div id="c1">c1</div>
+        <vaadin-horizontal-layout id="container" class="inner-layout">
+          <div id="c2">c2</div>
+        </vaadin-horizontal-layout>
+      </vaadin-horizontal-layout>
+    </template>
+  </test-fixture>
+
   <script>
     describe('basic tests', () => {
       let element, c1, c2;
@@ -129,6 +140,33 @@
         expect(getComputedStyle(element).getPropertyValue('padding-right')).to.equal('32px');
         expect(getComputedStyle(element).getPropertyValue('padding-bottom')).to.equal('32px');
         expect(getComputedStyle(element).getPropertyValue('padding-left')).to.equal('32px');
+      });
+    });
+
+    describe('nested', () => {
+      let element, inner, c1, c2;
+
+      beforeEach(() => {
+        element = fixture('nested');
+        inner = element.querySelector('.inner-layout');
+        c1 = element.querySelector('#c1');
+        c2 = inner.querySelector('#c2');
+      });
+
+      it('should support different gaps in nested layouts', () => {
+        inner.updateStyles({
+          '--vaadin-horizontal-layout-gap': '10px'
+        });
+
+        expect(getComputedStyle(c1).getPropertyValue('margin-left')).to.equal('16px');
+        expect(getComputedStyle(c1).getPropertyValue('margin-right')).to.equal('16px');
+        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-left')).to.equal('-16px');
+        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-right')).to.equal('-16px');
+
+        expect(getComputedStyle(c2).getPropertyValue('margin-left')).to.equal('5px');
+        expect(getComputedStyle(c2).getPropertyValue('margin-right')).to.equal('5px');
+        expect(getComputedStyle(inner.$.layout).getPropertyValue('margin-left')).to.equal('-5px');
+        expect(getComputedStyle(inner.$.layout).getPropertyValue('margin-right')).to.equal('-5px');
       });
     });
   </script>

--- a/test/horizontal-layout.html
+++ b/test/horizontal-layout.html
@@ -43,6 +43,11 @@
   </test-fixture>
 
   <script>
+
+    function getLayout(element) {
+      return element.shadowRoot.lastElementChild;
+    }
+
     describe('basic tests', () => {
       let element, c1, c2;
 
@@ -78,8 +83,8 @@
       });
 
       it('should compensate for gap in layout wrapper', () => {
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-left')).to.equal('-16px'); // -0.5 * 2em in px
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-right')).to.equal('-16px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-left')).to.equal('-16px'); // -0.5 * 2em in px
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-right')).to.equal('-16px');
       });
 
       it('should support updating with `updateStyles` call', () => {
@@ -91,8 +96,8 @@
         expect(getComputedStyle(c1).getPropertyValue('margin-left')).to.equal('10px'); // 0.5 * 20px in px
         expect(getComputedStyle(c2).getPropertyValue('margin-right')).to.equal('10px');
         expect(getComputedStyle(c2).getPropertyValue('margin-right')).to.equal('10px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-left')).to.equal('-10px'); // -0.5 * 20px in px
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-right')).to.equal('-10px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-left')).to.equal('-10px'); // -0.5 * 20px in px
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-right')).to.equal('-10px');
       });
     });
 
@@ -111,8 +116,8 @@
         expect(getComputedStyle(c1).getPropertyValue('margin-right')).to.equal('0px');
         expect(getComputedStyle(c2).getPropertyValue('margin-left')).to.equal('0px');
         expect(getComputedStyle(c2).getPropertyValue('margin-right')).to.equal('0px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-left')).to.equal('0px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-right')).to.equal('0px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-left')).to.equal('0px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-right')).to.equal('0px');
       });
 
       it('should not have margin or padding by default', () => {
@@ -160,13 +165,13 @@
 
         expect(getComputedStyle(c1).getPropertyValue('margin-left')).to.equal('16px');
         expect(getComputedStyle(c1).getPropertyValue('margin-right')).to.equal('16px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-left')).to.equal('-16px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-right')).to.equal('-16px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-left')).to.equal('-16px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-right')).to.equal('-16px');
 
         expect(getComputedStyle(c2).getPropertyValue('margin-left')).to.equal('5px');
         expect(getComputedStyle(c2).getPropertyValue('margin-right')).to.equal('5px');
-        expect(getComputedStyle(inner.$.layout).getPropertyValue('margin-left')).to.equal('-5px');
-        expect(getComputedStyle(inner.$.layout).getPropertyValue('margin-right')).to.equal('-5px');
+        expect(getComputedStyle(getLayout(inner)).getPropertyValue('margin-left')).to.equal('-5px');
+        expect(getComputedStyle(getLayout(inner)).getPropertyValue('margin-right')).to.equal('-5px');
       });
     });
   </script>

--- a/test/vertical-layout.html
+++ b/test/vertical-layout.html
@@ -31,6 +31,17 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="nested">
+    <template>
+      <vaadin-vertical-layout id="container">
+        <div id="c1">c1</div>
+        <vaadin-vertical-layout id="container" class="inner-layout">
+          <div id="c2">c2</div>
+        </vaadin-vertical-layout>
+      </vaadin-vertical-layout>
+    </template>
+  </test-fixture>
+
   <script>
     describe('basic tests', () => {
       let element, c1, c2;
@@ -131,6 +142,33 @@
         expect(getComputedStyle(element).getPropertyValue('padding-right')).to.equal('32px');
         expect(getComputedStyle(element).getPropertyValue('padding-bottom')).to.equal('32px');
         expect(getComputedStyle(element).getPropertyValue('padding-left')).to.equal('32px');
+      });
+    });
+
+    describe('nested', () => {
+      let element, inner, c1, c2;
+
+      beforeEach(() => {
+        element = fixture('nested');
+        inner = element.querySelector('.inner-layout');
+        c1 = element.querySelector('#c1');
+        c2 = inner.querySelector('#c2');
+      });
+
+      it('should support different gaps in nested layouts', () => {
+        inner.updateStyles({
+          '--vaadin-vertical-layout-gap': '10px'
+        });
+
+        expect(getComputedStyle(c1).getPropertyValue('margin-top')).to.equal('16px');
+        expect(getComputedStyle(c1).getPropertyValue('margin-bottom')).to.equal('16px');
+        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-top')).to.equal('-16px');
+        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-bottom')).to.equal('-16px');
+
+        expect(getComputedStyle(c2).getPropertyValue('margin-top')).to.equal('5px');
+        expect(getComputedStyle(c2).getPropertyValue('margin-bottom')).to.equal('5px');
+        expect(getComputedStyle(inner.$.layout).getPropertyValue('margin-top')).to.equal('-5px');
+        expect(getComputedStyle(inner.$.layout).getPropertyValue('margin-bottom')).to.equal('-5px');
       });
     });
   </script>

--- a/test/vertical-layout.html
+++ b/test/vertical-layout.html
@@ -43,6 +43,10 @@
   </test-fixture>
 
   <script>
+    function getLayout(element) {
+      return element.shadowRoot.lastElementChild;
+    }
+
     describe('basic tests', () => {
       let element, c1, c2;
 
@@ -80,8 +84,8 @@
       });
 
       it('should compensate for gap in layout wrapper', () => {
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-top')).to.equal('-16px'); // -0.5 * 2em in px
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-bottom')).to.equal('-16px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-top')).to.equal('-16px'); // -0.5 * 2em in px
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-bottom')).to.equal('-16px');
       });
 
       it('should support updating with `updateStyles` call', () => {
@@ -93,8 +97,8 @@
         expect(getComputedStyle(c1).getPropertyValue('margin-bottom')).to.equal('10px');
         expect(getComputedStyle(c2).getPropertyValue('margin-top')).to.equal('10px'); // 0.5 * 20px in px
         expect(getComputedStyle(c2).getPropertyValue('margin-bottom')).to.equal('10px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-top')).to.equal('-10px'); // -0.5 * 20px in px
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-bottom')).to.equal('-10px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-top')).to.equal('-10px'); // -0.5 * 20px in px
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-bottom')).to.equal('-10px');
       });
     });
 
@@ -113,8 +117,8 @@
         expect(getComputedStyle(c1).getPropertyValue('margin-right')).to.equal('0px');
         expect(getComputedStyle(c2).getPropertyValue('margin-left')).to.equal('0px');
         expect(getComputedStyle(c2).getPropertyValue('margin-right')).to.equal('0px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-left')).to.equal('0px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-right')).to.equal('0px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-left')).to.equal('0px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-right')).to.equal('0px');
       });
 
       it('should not have margin or padding by default', () => {
@@ -162,13 +166,13 @@
 
         expect(getComputedStyle(c1).getPropertyValue('margin-top')).to.equal('16px');
         expect(getComputedStyle(c1).getPropertyValue('margin-bottom')).to.equal('16px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-top')).to.equal('-16px');
-        expect(getComputedStyle(element.$.layout).getPropertyValue('margin-bottom')).to.equal('-16px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-top')).to.equal('-16px');
+        expect(getComputedStyle(getLayout(element)).getPropertyValue('margin-bottom')).to.equal('-16px');
 
         expect(getComputedStyle(c2).getPropertyValue('margin-top')).to.equal('5px');
         expect(getComputedStyle(c2).getPropertyValue('margin-bottom')).to.equal('5px');
-        expect(getComputedStyle(inner.$.layout).getPropertyValue('margin-top')).to.equal('-5px');
-        expect(getComputedStyle(inner.$.layout).getPropertyValue('margin-bottom')).to.equal('-5px');
+        expect(getComputedStyle(getLayout(inner)).getPropertyValue('margin-top')).to.equal('-5px');
+        expect(getComputedStyle(getLayout(inner)).getPropertyValue('margin-bottom')).to.equal('-5px');
       });
     });
   </script>

--- a/vaadin-horizontal-layout.html
+++ b/vaadin-horizontal-layout.html
@@ -23,12 +23,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
       /* Theme variations */
 
-      :host([theme~="gap-none"]) #layout {
+      :host([theme~="gap-none"]) vaadin-horizontal-layout-container {
         margin-left: 0;
         margin-right: 0;
       }
 
-      :host([theme~="gap-none"]) #layout ::slotted(*) {
+      :host([theme~="gap-none"]) vaadin-horizontal-layout-container ::slotted(*) {
         margin-left: 0;
         margin-right: 0;
       }
@@ -42,7 +42,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
 
-    <vaadin-horizontal-layout-container id="layout">
+    <vaadin-horizontal-layout-container>
       <slot></slot>
     </vaadin-horizontal-layout-container>
   </template>

--- a/vaadin-horizontal-layout.html
+++ b/vaadin-horizontal-layout.html
@@ -21,27 +21,6 @@ This program is available under Apache License Version 2.0, available at https:/
         display: none !important;
       }
 
-      #layout {
-        display: flex;
-        flex: 1 1 auto;
-
-        /*
-          Compensate for item margins, so that there are no gaps around
-          the layout itself.
-        */
-        margin-left: calc(-0.5 * var(--vaadin-horizontal-layout-gap));
-        margin-right: calc(-0.5 * var(--vaadin-horizontal-layout-gap));
-      }
-
-      #layout ::slotted(*) {
-        /* Enable grow and shrink for items. */
-        flex: 1 1 auto;
-
-        /* Margins make gaps between items */
-        margin-left: calc(0.5 * var(--vaadin-horizontal-layout-gap));
-        margin-right: calc(0.5 * var(--vaadin-horizontal-layout-gap));
-      }
-
       /* Theme variations */
 
       :host([theme~="gap-none"]) #layout {
@@ -63,16 +42,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
 
-    <div id="layout">
+    <vaadin-horizontal-layout-container id="layout">
       <slot></slot>
-    </div>
+    </vaadin-horizontal-layout-container>
   </template>
 
   <script>
-    if (!Polymer.Element) {
-      throw new Error(`Unexpected Polymer version ${Polymer.version} is used, expected v2.0.0 or later.`);
-    }
-
     {
       /**
        * `<vaadin-horizontal-layout>` provides a simple way to horizontally align your HTML elements.
@@ -124,6 +99,49 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       window.Vaadin = window.Vaadin || {};
       Vaadin.HorizontalLayoutElement = HorizontalLayoutElement;
+    }
+  </script>
+</dom-module>
+
+<dom-module id="vaadin-horizontal-layout-container">
+  <template>
+    <style>
+      :host {
+        display: flex;
+        flex: 1 1 auto;
+        /* Internal CSS property used for scoping --vaadin-horizontal-layout-gap */
+        --vaadin-horizontal-layout-gap-scoped: var(--vaadin-horizontal-layout-gap);
+
+        /*
+          Compensate for item margins, so that there are no gaps around
+          the layout itself.
+        */
+        margin-left: calc(-0.5 * var(--vaadin-horizontal-layout-gap-scoped));
+        margin-right: calc(-0.5 * var(--vaadin-horizontal-layout-gap-scoped));
+      }
+
+      :host ::slotted(*) {
+        /* Enable grow and shrink for items. */
+        flex: 1 1 auto;
+
+        /* Margins make gaps between items */
+        margin-left: calc(0.5 * var(--vaadin-horizontal-layout-gap-scoped));
+        margin-right: calc(0.5 * var(--vaadin-horizontal-layout-gap-scoped));
+      }
+    </style>
+    <slot></slot>
+  </template>
+  <script>
+    {
+      /**
+       * For internal use only
+       */
+      class VaadinHorizontalLayoutContainer extends Polymer.Element {
+        static get is() {
+          return 'vaadin-horizontal-layout-container';
+        }
+      }
+      customElements.define(VaadinHorizontalLayoutContainer.is, VaadinHorizontalLayoutContainer);
     }
   </script>
 </dom-module>

--- a/vaadin-vertical-layout.html
+++ b/vaadin-vertical-layout.html
@@ -23,12 +23,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
       /* Theme variations */
 
-      :host([theme~="gap-none"]) #layout {
+      :host([theme~="gap-none"]) vaadin-vertical-layout-container {
         margin-top: 0;
         margin-bottom: 0;
       }
 
-      :host([theme~="gap-none"]) #layout ::slotted(*) {
+      :host([theme~="gap-none"]) vaadin-vertical-layout-container ::slotted(*) {
         margin-top: 0;
         margin-bottom: 0;
       }
@@ -42,7 +42,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
 
-    <vaadin-vertical-layout-container id="layout">
+    <vaadin-vertical-layout-container>
       <slot></slot>
     </vaadin-vertical-layout-container>
   </template>

--- a/vaadin-vertical-layout.html
+++ b/vaadin-vertical-layout.html
@@ -21,28 +21,6 @@ This program is available under Apache License Version 2.0, available at https:/
         display: none !important;
       }
 
-      #layout {
-        display: flex;
-        flex-direction: column;
-        flex: 1 1 auto;
-
-        /*
-          Compensate for item margins, so that there are no gaps around
-          the layout itself.
-        */
-        margin-top: calc(-0.5 * var(--vaadin-vertical-layout-gap));
-        margin-bottom: calc(-0.5 * var(--vaadin-vertical-layout-gap));
-      }
-
-      #layout ::slotted(*) {
-        /* Enable grow and shrink for items. */
-        flex: 1 1 auto;
-
-        /* Margins make gaps between items */
-        margin-top: calc(0.5 * var(--vaadin-vertical-layout-gap));
-        margin-bottom: calc(0.5 * var(--vaadin-vertical-layout-gap));
-      }
-
       /* Theme variations */
 
       :host([theme~="gap-none"]) #layout {
@@ -64,16 +42,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
 
-    <div id="layout">
+    <vaadin-vertical-layout-container id="layout">
       <slot></slot>
-    </div>
+    </vaadin-vertical-layout-container>
   </template>
 
   <script>
-    if (!Polymer.Element) {
-      throw new Error(`Unexpected Polymer version ${Polymer.version} is used, expected v2.0.0 or later.`);
-    }
-
     {
       /**
        * `<vaadin-vertical-layout>` provides a simple way to vertically align your HTML elements.
@@ -125,6 +99,50 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       window.Vaadin = window.Vaadin || {};
       Vaadin.VerticalLayoutElement = VerticalLayoutElement;
+    }
+  </script>
+</dom-module>
+
+<dom-module id="vaadin-vertical-layout-container">
+  <template>
+    <style>
+      :host {
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        /* Internal CSS property used for scoping --vaadin-vertical-layout-gap */
+        --vaadin-vertical-layout-gap-scoped: var(--vaadin-vertical-layout-gap);
+
+        /*
+          Compensate for item margins, so that there are no gaps around
+          the layout itself.
+        */
+        margin-top: calc(-0.5 * var(--vaadin-vertical-layout-gap-scoped));
+        margin-bottom: calc(-0.5 * var(--vaadin-vertical-layout-gap-scoped));
+      }
+
+      :host ::slotted(*) {
+        /* Enable grow and shrink for items. */
+        flex: 1 1 auto;
+
+        /* Margins make gaps between items */
+        margin-top: calc(0.5 * var(--vaadin-vertical-layout-gap-scoped));
+        margin-bottom: calc(0.5 * var(--vaadin-vertical-layout-gap-scoped));
+      }
+    </style>
+    <slot></slot>
+  </template>
+  <script>
+    {
+      /**
+       * For internal use only
+       */
+      class VaadinVerticalLayoutContainer extends Polymer.Element {
+        static get is() {
+          return 'vaadin-vertical-layout-container';
+        }
+      }
+      customElements.define(VaadinVerticalLayoutContainer.is, VaadinVerticalLayoutContainer);
     }
   </script>
 </dom-module>


### PR DESCRIPTION
Fixes #14 

Requires second shadow root level so the approach works with Shady CSS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-ordered-layout/20)
<!-- Reviewable:end -->
