### PR TITLE
Add max-width to slotted items in vertical-layout

### DIFF
--- a/src/vaadin-vertical-layout.html
+++ b/src/vaadin-vertical-layout.html
@@ -31,6 +31,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       :host([theme~="spacing"]) ::slotted(*) {
         margin-top: 1em;
+        max-width: 100%;
       }
 
       /*

--- a/test/vertical-layout.html
+++ b/test/vertical-layout.html
@@ -109,6 +109,12 @@
         expect(getComputedStyle(c2).getPropertyValue('margin-top')).to.equal(space);
       });
 
+      it('should set max-width to slotted items with theme="spacing"', () => {
+        element.setAttribute('theme', 'spacing');
+        expect(getComputedStyle(c1).getPropertyValue('max-width')).to.equal('100%');
+        expect(getComputedStyle(c2).getPropertyValue('max-width')).to.equal('100%');
+      });
+
       it('should compensate first item margin for theme="spacing"', () => {
         element.setAttribute('theme', 'spacing');
         const margin = getComputedStyle(element, '::before').getPropertyValue('margin-top');


### PR DESCRIPTION
The issue https://github.com/vaadin/vaadin-form-layout/issues/54 was caused by incorrect calculation of the width.

Fixes https://github.com/vaadin/vaadin-form-layout/issues/54

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-ordered-layout/37)
<!-- Reviewable:end -->
