### PR TITLE
Update main field in package.json to use common import

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
   "description": "vaadin-ordered-layout",
   "main": [
     "vaadin-horizontal-layout.html",
-    "vaadin-vertical-layout.html"
+    "vaadin-vertical-layout.html",
+    "imports.html"
   ],
   "keywords": [
     "Vaadin",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vaadin/vaadin-ordered-layout",
   "version": "1.0.1-pre.2",
   "description": "vaadin-ordered-layout",
-  "main": "vaadin-ordered-layout.html",
+  "main": "imports.html",
   "repository": "vaadin/vaadin-ordered-layout",
   "keywords": [
     "Vaadin",


### PR DESCRIPTION
Fixes #45

In `package.json` the "main" field should be string, so that the import below should work:

`import '@vaadin/vaadin-ordered-layout/vaadin-ordered-layout'`

Therefore we should use common import file here, and we also need it in `bower.json` for modulizer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-ordered-layout/51)
<!-- Reviewable:end -->
