### PR TITLE
Use CSS Grid display

### DIFF
--- a/src/vaadin-horizontal-layout.html
+++ b/src/vaadin-horizontal-layout.html
@@ -12,7 +12,9 @@ This program is available under Apache License Version 2.0, available at https:/
   <template>
     <style>
       :host {
-        display: flex;
+        display: grid;
+        grid-auto-flow: column;
+        grid-auto-columns: min-content;
         box-sizing: border-box;
       }
 
@@ -29,17 +31,8 @@ This program is available under Apache License Version 2.0, available at https:/
         padding: 1em;
       }
 
-      :host([theme~="spacing"]) ::slotted(*) {
-        margin-left: 1em;
-      }
-
-      /*
-        Compensate for the first item margin, so that there is no gap around
-        the layout itself.
-       */
-      :host([theme~="spacing"])::before {
-        content: "";
-        margin-left: -1em;
+      :host([theme~="spacing"]) {
+        grid-column-gap: 1em;
       }
     </style>
 

--- a/src/vaadin-vertical-layout.html
+++ b/src/vaadin-vertical-layout.html
@@ -12,9 +12,10 @@ This program is available under Apache License Version 2.0, available at https:/
   <template>
     <style>
       :host {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
+        display: grid;
+        grid-auto-flow: row;
+        grid-auto-rows: min-content;
+        grid-auto-columns: min-content;
         box-sizing: border-box;
       }
 
@@ -31,17 +32,8 @@ This program is available under Apache License Version 2.0, available at https:/
         padding: 1em;
       }
 
-      :host([theme~="spacing"]) ::slotted(*) {
-        margin-top: 1em;
-      }
-
-      /*
-        Compensate for the first item margin, so that there is no gap around
-        the layout itself.
-       */
-      :host([theme~="spacing"])::before {
-        content: "";
-        margin-top: -1em;
+      :host([theme~="spacing"]) {
+        grid-row-gap: 1em;
       }
     </style>
 

--- a/test/horizontal-layout.html
+++ b/test/horizontal-layout.html
@@ -73,12 +73,10 @@
     });
 
     describe('theme variations', () => {
-      let element, c1, c2, space;
+      let element, space;
 
       beforeEach(() => {
         element = fixture('default');
-        c1 = element.querySelector('#c1');
-        c2 = element.querySelector('#c2');
         space = window.getComputedCSSPropertyValue(element, '--lumo-space-m');
       });
 
@@ -111,20 +109,7 @@
 
       it('should support theme="spacing"', () => {
         element.setAttribute('theme', 'spacing');
-        expect(getComputedStyle(c1).getPropertyValue('margin-left')).to.equal(space);
-        expect(getComputedStyle(c2).getPropertyValue('margin-left')).to.equal(space);
-      });
-
-      it('should compensate first item margin for theme="spacing"', () => {
-        element.setAttribute('theme', 'spacing');
-        const margin = getComputedStyle(element, '::before').getPropertyValue('margin-left');
-        // in Edge `getComputedStyle` returns `calc` expression for pseudo elements
-        if (navigator.userAgent.match(/Edge/)) {
-          expect(margin).to.contain('-1');
-          expect(margin).to.contain('rem');
-        } else {
-          expect(margin).to.equal('-' + space);
-        }
+        expect(getComputedStyle(element).getPropertyValue('grid-column-gap')).to.equal(space);
       });
     });
 

--- a/test/vertical-layout.html
+++ b/test/vertical-layout.html
@@ -74,12 +74,10 @@
     });
 
     describe('theme variations', () => {
-      let element, c1, c2, space;
+      let element, space;
 
       beforeEach(() => {
         element = fixture('default');
-        c1 = element.querySelector('#c1');
-        c2 = element.querySelector('#c2');
         space = window.getComputedCSSPropertyValue(element, '--lumo-space-m');
       });
 
@@ -112,20 +110,7 @@
 
       it('should support theme="spacing"', () => {
         element.setAttribute('theme', 'spacing');
-        expect(getComputedStyle(c1).getPropertyValue('margin-top')).to.equal(space);
-        expect(getComputedStyle(c2).getPropertyValue('margin-top')).to.equal(space);
-      });
-
-      it('should compensate first item margin for theme="spacing"', () => {
-        element.setAttribute('theme', 'spacing');
-        const margin = getComputedStyle(element, '::before').getPropertyValue('margin-top');
-        // in Edge `getComputedStyle` returns `calc` expression for pseudo elements
-        if (navigator.userAgent.match(/Edge/)) {
-          expect(margin).to.contain('-1');
-          expect(margin).to.contain('rem');
-        } else {
-          expect(margin).to.equal('-' + space);
-        }
+        expect(getComputedStyle(element).getPropertyValue('grid-row-gap')).to.equal(space);
       });
     });
 

--- a/theme/lumo/vaadin-horizontal-layout-styles.html
+++ b/theme/lumo/vaadin-horizontal-layout-styles.html
@@ -4,53 +4,24 @@
 <dom-module id="lumo-horizontal-layout" theme-for="vaadin-horizontal-layout">
   <template>
     <style include="lumo-ordered-layout">
-      :host([theme~="spacing-xs"]) ::slotted(*) {
-        margin-left: var(--lumo-space-xs);
+      :host([theme~="spacing-xs"]) {
+        grid-column-gap: var(--lumo-space-xs);
       }
 
-      :host([theme~="spacing-s"]) ::slotted(*) {
-        margin-left: var(--lumo-space-s);
+      :host([theme~="spacing-s"]) {
+        grid-column-gap: var(--lumo-space-s);
       }
 
-      :host([theme~="spacing"]) ::slotted(*) {
-        margin-left: var(--lumo-space-m);
+      :host([theme~="spacing"]) {
+        grid-column-gap: var(--lumo-space-m);
       }
 
-      :host([theme~="spacing-l"]) ::slotted(*) {
-        margin-left: var(--lumo-space-l);
+      :host([theme~="spacing-l"]) {
+        grid-column-gap: var(--lumo-space-l);
       }
 
-      :host([theme~="spacing-xl"]) ::slotted(*) {
-        margin-left: var(--lumo-space-xl);
-      }
-
-      /*
-        Compensate for the first item margin, so that there is no gap around
-        the layout itself.
-       */
-      :host([theme~="spacing-xs"])::before {
-        content: "";
-        margin-left: calc(var(--lumo-space-xs) * -1);
-      }
-
-      :host([theme~="spacing-s"])::before {
-        content: "";
-        margin-left: calc(var(--lumo-space-s) * -1);
-      }
-
-      :host([theme~="spacing"])::before {
-        content: "";
-        margin-left: calc(var(--lumo-space-m) * -1);
-      }
-
-      :host([theme~="spacing-l"])::before {
-        content: "";
-        margin-left: calc(var(--lumo-space-l) * -1);
-      }
-
-      :host([theme~="spacing-xl"])::before {
-        content: "";
-        margin-left: calc(var(--lumo-space-xl) * -1);
+      :host([theme~="spacing-xl"]) {
+        grid-column-gap: var(--lumo-space-xl);
       }
     </style>
   </template>

--- a/theme/lumo/vaadin-vertical-layout-styles.html
+++ b/theme/lumo/vaadin-vertical-layout-styles.html
@@ -4,53 +4,24 @@
 <dom-module id="lumo-vertical-layout" theme-for="vaadin-vertical-layout">
   <template>
     <style include="lumo-ordered-layout">
-      :host([theme~="spacing-xs"]) ::slotted(*) {
-        margin-top: var(--lumo-space-xs);
+      :host([theme~="spacing-xs"]) {
+        grid-row-gap: var(--lumo-space-xs);
       }
 
-      :host([theme~="spacing-s"]) ::slotted(*) {
-        margin-top: var(--lumo-space-s);
+      :host([theme~="spacing-s"]) {
+        grid-row-gap: var(--lumo-space-s);
       }
 
-      :host([theme~="spacing"]) ::slotted(*) {
-        margin-top: var(--lumo-space-m);
+      :host([theme~="spacing"]) {
+        grid-row-gap: var(--lumo-space-m);
       }
 
-      :host([theme~="spacing-l"]) ::slotted(*) {
-        margin-top: var(--lumo-space-l);
+      :host([theme~="spacing-l"]) {
+        grid-row-gap: var(--lumo-space-l);
       }
 
-      :host([theme~="spacing-xl"]) ::slotted(*) {
-        margin-top: var(--lumo-space-xl);
-      }
-
-      /*
-        Compensate for the first item margin, so that there is no gap around
-        the layout itself.
-       */
-       :host([theme~="spacing-xs"])::before {
-         content: "";
-         margin-top: calc(var(--lumo-space-xs) * -1);
-       }
-
-       :host([theme~="spacing-s"])::before {
-         content: "";
-         margin-top: calc(var(--lumo-space-s) * -1);
-       }
-
-      :host([theme~="spacing"])::before {
-        content: "";
-        margin-top: calc(var(--lumo-space-m) * -1);
-      }
-
-      :host([theme~="spacing-l"])::before {
-        content: "";
-        margin-top: calc(var(--lumo-space-l) * -1);
-      }
-
-      :host([theme~="spacing-xl"])::before {
-        content: "";
-        margin-top: calc(var(--lumo-space-xl) * -1);
+      :host([theme~="spacing-xl"]) {
+        grid-row-gap: var(--lumo-space-xl);
       }
     </style>
   </template>

--- a/theme/material/vaadin-horizontal-layout-styles.html
+++ b/theme/material/vaadin-horizontal-layout-styles.html
@@ -3,53 +3,24 @@
 <dom-module id="material-horizontal-layout" theme-for="vaadin-horizontal-layout">
   <template>
     <style include="material-ordered-layout">
-      :host([theme~="spacing-xs"]) ::slotted(*) {
-        margin-left: 4px;
+      :host([theme~="spacing-xs"]) {
+        grid-column-gap: 4px;
       }
 
-      :host([theme~="spacing-s"]) ::slotted(*) {
-        margin-left: 8px;
+      :host([theme~="spacing-s"]) {
+        grid-column-gap: 8px;
       }
 
-      :host([theme~="spacing"]) ::slotted(*) {
-        margin-left: 16px;
+      :host([theme~="spacing"]) {
+        grid-column-gap: 16px;
       }
 
-      :host([theme~="spacing-l"]) ::slotted(*) {
-        margin-left: 24px;
+      :host([theme~="spacing-l"]) {
+        grid-column-gap: 24px;
       }
 
-      :host([theme~="spacing-xl"]) ::slotted(*) {
-        margin-left: 40px;
-      }
-
-      /*
-        Compensate for the first item margin, so that there is no gap around
-        the layout itself.
-       */
-      :host([theme~="spacing-xs"])::before {
-        content: "";
-        margin-left: -4px;
-      }
-
-      :host([theme~="spacing-s"])::before {
-        content: "";
-        margin-left: -8px;
-      }
-
-      :host([theme~="spacing"])::before {
-        content: "";
-        margin-left: -16px;
-      }
-
-      :host([theme~="spacing-l"])::before {
-        content: "";
-        margin-left: -24px;
-      }
-
-      :host([theme~="spacing-xl"])::before {
-        content: "";
-        margin-left: -40px;
+      :host([theme~="spacing-xl"]) {
+        grid-column-gap: 40px;
       }
     </style>
   </template>

--- a/theme/material/vaadin-vertical-layout-styles.html
+++ b/theme/material/vaadin-vertical-layout-styles.html
@@ -3,53 +3,24 @@
 <dom-module id="material-vertical-layout" theme-for="vaadin-vertical-layout">
   <template>
     <style include="material-ordered-layout">
-      :host([theme~="spacing-xs"]) ::slotted(*) {
-        margin-top: 4px;
+      :host([theme~="spacing-xs"]) {
+        grid-row-gap: 4px;
       }
 
-      :host([theme~="spacing-s"]) ::slotted(*) {
-        margin-top: 8px;
+      :host([theme~="spacing-s"]) {
+        grid-row-gap: 8px;
       }
 
-      :host([theme~="spacing"]) ::slotted(*) {
-        margin-top: 16px;
+      :host([theme~="spacing"]) {
+        grid-row-gap: 16px;
       }
 
-      :host([theme~="spacing-l"]) ::slotted(*) {
-        margin-top: 32px;
+      :host([theme~="spacing-l"]) {
+        grid-row-gap: 32px;
       }
 
-      :host([theme~="spacing-xl"]) ::slotted(*) {
-        margin-top: 64px;
-      }
-
-      /*
-        Compensate for the first item margin, so that there is no gap around
-        the layout itself.
-       */
-      :host([theme~="spacing-xs"])::before {
-        content: "";
-        margin-top: -4px;
-      }
-
-      :host([theme~="spacing-s"])::before {
-        content: "";
-        margin-top: -8px;
-       }
-
-      :host([theme~="spacing"])::before {
-        content: "";
-        margin-top: -16px;
-      }
-
-      :host([theme~="spacing-l"])::before {
-        content: "";
-        margin-top: -32px;
-      }
-
-      :host([theme~="spacing-xl"])::before {
-        content: "";
-        margin-top: -64px;
+      :host([theme~="spacing-xl"]) {
+        grid-row-gap: 64px;
       }
     </style>
   </template>


### PR DESCRIPTION
This introduces CSS Grid display mode for ordered layouts.

With `display: grid`, spacing between rows/columns can be easily set with `grid-row-gap` and `grid-column-gap` without the need of pseudo-elements hacks (and their side-effects, e.g. #66).

Also, items can now wrap and keep the correct gaps, fixing also #52.

Adopting CSS Grid may also lead the way to new ordered layouts (e.g. multi-dimensional) and new layout features.

Browser support: https://caniuse.com/css-grid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-ordered-layout/67)
<!-- Reviewable:end -->
