### PR TITLE
vaadin-scroll-container

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,9 +8,11 @@
   "main": [
     "vaadin-horizontal-layout.html",
     "vaadin-vertical-layout.html",
+    "vaadin-scroll-container.html",
     "imports.html",
     "theme/material/vaadin-horizontal-layout.html",
-    "theme/material/vaadin-vertical-layout.html"
+    "theme/material/vaadin-vertical-layout.html",
+    "theme/material/vaadin-scroll-container.html"
   ],
   "keywords": [
     "Vaadin",

--- a/imports.html
+++ b/imports.html
@@ -1,2 +1,3 @@
 <link rel="import" href="vaadin-horizontal-layout.html">
 <link rel="import" href="vaadin-vertical-layout.html">
+<link rel="import" href="vaadin-scroll-container.html">

--- a/src/vaadin-scroll-container.html
+++ b/src/vaadin-scroll-container.html
@@ -1,6 +1,6 @@
 <!--
 @license
-Copyright (c) 2017 Vaadin Ltd.
+Copyright (c) 2020 Vaadin Ltd.
 This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
 -->
 
@@ -11,6 +11,10 @@ This program is available under Apache License Version 2.0, available at https:/
 <dom-module id="vaadin-scroll-container">
   <template>
     <style>
+      :host([hidden]) {
+        display: none !important;
+      }
+
       :host {
         display: block;
         overflow: auto;
@@ -23,7 +27,6 @@ This program is available under Apache License Version 2.0, available at https:/
       :host([vertical-scroll-disabled]) {
         overflow-y: hidden;
       }
-
     </style>
 
     <slot></slot>

--- a/src/vaadin-scroll-container.html
+++ b/src/vaadin-scroll-container.html
@@ -1,0 +1,75 @@
+<!--
+@license
+Copyright (c) 2017 Vaadin Ltd.
+This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+-->
+
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
+<link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
+
+<dom-module id="vaadin-scroll-container">
+  <template>
+    <style>
+      :host {
+        display: block;
+        overflow: auto;
+      }
+
+      :host([horizontal-scroll-disabled]) {
+        overflow-x: hidden;
+      }
+
+      :host([vertical-scroll-disabled]) {
+        overflow-y: hidden;
+      }
+
+    </style>
+
+    <slot></slot>
+
+  </template>
+
+  <script>
+    (function() {
+      /**
+       * `<vaadin-scroll-container>` provides a simple way to display scrollbars when its content is overflowing.
+       *
+       * ```
+       * <vaadin-scroll-container>
+       *   <div>Content</div>
+       * </vaadin-scroll-container>
+       * ```
+       * ### Styling
+       *
+       * The following state attributes are available for styling:
+       *
+       * Attribute    | Description
+       * -------------|-------------
+       * `horizontal-scroll-disabled` | Set to disable horizontal scrolling
+       * `vertical-scroll-disabled` | Set to disable vertical scrolling
+       *
+       * @memberof Vaadin
+       * @mixes Vaadin.ThemableMixin
+       * @demo demo/index.html
+       */
+      class ScrollContainerElement extends Vaadin.ElementMixin(Vaadin.ThemableMixin(Polymer.Element)) {
+        static get is() {
+          return 'vaadin-scroll-container';
+        }
+
+        static get version() {
+          return '1.1.0';
+        }
+      }
+
+      customElements.define(ScrollContainerElement.is, ScrollContainerElement);
+
+      /**
+       * @namespace Vaadin
+       */
+      window.Vaadin = window.Vaadin || {};
+      Vaadin.ScrollContainerElement = ScrollContainerElement;
+    })();
+  </script>
+</dom-module>

--- a/test/scroll-container.html
+++ b/test/scroll-container.html
@@ -2,7 +2,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>vaadin-horizontal-layout tests</title>
+  <title>vaadin-scroll-container tests</title>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
@@ -13,7 +13,7 @@
 <body>
   <test-fixture id="default">
     <template>
-      <vaadin-scroll-container id="container">
+      <vaadin-scroll-container>
       </vaadin-scroll-container>
     </template>
   </test-fixture>

--- a/test/scroll-container.html
+++ b/test/scroll-container.html
@@ -1,0 +1,53 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-horizontal-layout tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../vaadin-scroll-container.html">
+  <link rel="import" href="common.html">
+</head>
+
+<body>
+  <test-fixture id="default">
+    <template>
+      <vaadin-scroll-container id="container">
+      </vaadin-scroll-container>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('basic tests', () => {
+      let element;
+
+      beforeEach(() => {
+        element = fixture('default');
+      });
+
+      it('should have horizontal scrollbars by default', () => {
+        expect(getComputedStyle(element).overflowX).to.equal('auto');
+      });
+
+      it('should have vertical scrollbars by default', () => {
+        expect(getComputedStyle(element).overflowY).to.equal('auto');
+      });
+
+      it('should be possible to disable horizontal scrollbars', () => {
+        element.setAttribute('horizontal-scroll-disabled', '');
+        expect(getComputedStyle(element).overflowX).to.equal('hidden');
+      });
+
+      it('should be possible to disable vertical scrollbars', () => {
+        element.setAttribute('vertical-scroll-disabled', '');
+        expect(getComputedStyle(element).overflowY).to.equal('hidden');
+      });
+
+      it('should extend Vaadin.ThemableMixin', () => {
+        expect(element.constructor._includeStyle).to.be.function;
+      });
+    });
+
+  </script>
+</body>

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -1,4 +1,5 @@
 window.VaadinOrderedLayoutSuites = [
   'horizontal-layout.html',
-  'vertical-layout.html'
+  'vertical-layout.html',
+  'scroll-container.html'
 ];

--- a/theme/lumo/vaadin-scroll-container.html
+++ b/theme/lumo/vaadin-scroll-container.html
@@ -1,0 +1,1 @@
+<link rel="import" href="../../src/vaadin-scroll-container.html">

--- a/theme/material/vaadin-scroll-container.html
+++ b/theme/material/vaadin-scroll-container.html
@@ -1,0 +1,1 @@
+<link rel="import" href="../../src/vaadin-scroll-container.html">

--- a/vaadin-scroll-container.html
+++ b/vaadin-scroll-container.html
@@ -1,0 +1,1 @@
+<link rel="import" href="theme/lumo/vaadin-scroll-container.html">


### PR DESCRIPTION
• Simple slotted component that will display scrollbars when its content is overflowing and can be used in existing layouts.

• Scroll should be auto by default and can be disabled on a specific direction

Fixes #77