### PR TITLE
Re-implement scroll-container using scroll-direction attribute

### DIFF
--- a/src/vaadin-scroll-container.html
+++ b/src/vaadin-scroll-container.html
@@ -20,12 +20,16 @@ This program is available under Apache License Version 2.0, available at https:/
         overflow: auto;
       }
 
-      :host([horizontal-scroll-disabled]) {
+      :host([scroll-direction='vertical']) {
         overflow-x: hidden;
       }
 
-      :host([vertical-scroll-disabled]) {
+      :host([scroll-direction='horizontal']) {
         overflow-y: hidden;
+      }
+
+      :host([scroll-direction='none']) {
+        overflow: hidden;
       }
     </style>
 
@@ -43,14 +47,6 @@ This program is available under Apache License Version 2.0, available at https:/
        *   <div>Content</div>
        * </vaadin-scroll-container>
        * ```
-       * ### Styling
-       *
-       * The following state attributes are available for styling:
-       *
-       * Attribute    | Description
-       * -------------|-------------
-       * `horizontal-scroll-disabled` | Set to disable horizontal scrolling
-       * `vertical-scroll-disabled` | Set to disable vertical scrolling
        *
        * @memberof Vaadin
        * @mixes Vaadin.ThemableMixin
@@ -59,6 +55,19 @@ This program is available under Apache License Version 2.0, available at https:/
       class ScrollContainerElement extends Vaadin.ElementMixin(Vaadin.ThemableMixin(Polymer.Element)) {
         static get is() {
           return 'vaadin-scroll-container';
+        }
+
+        static get properties() {
+          return {
+            /**
+            * This property indicates the scroll direction. Supported values are `vertical`, `horizontal`, `none`.
+            * When `scrollDirection` is undefined scrollbars will be shown in both directions.
+            */
+            scrollDirection: {
+              type: String,
+              reflectToAttribute: true
+            }
+          };
         }
 
         static get version() {

--- a/test/scroll-container.html
+++ b/test/scroll-container.html
@@ -26,21 +26,26 @@
         element = fixture('default');
       });
 
-      it('should have horizontal scrollbars by default', () => {
+      it('should have horizontal and vertical scrollbars by default', () => {
         expect(getComputedStyle(element).overflowX).to.equal('auto');
-      });
-
-      it('should have vertical scrollbars by default', () => {
         expect(getComputedStyle(element).overflowY).to.equal('auto');
       });
 
-      it('should be possible to disable horizontal scrollbars', () => {
-        element.setAttribute('horizontal-scroll-disabled', '');
+      it('should be possible to enable only vertical scrollbars', () => {
+        element.setAttribute('scroll-direction', 'vertical');
+        expect(getComputedStyle(element).overflowY).to.equal('auto');
         expect(getComputedStyle(element).overflowX).to.equal('hidden');
       });
 
-      it('should be possible to disable vertical scrollbars', () => {
-        element.setAttribute('vertical-scroll-disabled', '');
+      it('should be possible to enable only horizontal scrollbars', () => {
+        element.setAttribute('scroll-direction', 'horizontal');
+        expect(getComputedStyle(element).overflowX).to.equal('auto');
+        expect(getComputedStyle(element).overflowY).to.equal('hidden');
+      });
+
+      it('should be possible to disable both direction scrollbars', () => {
+        element.setAttribute('scroll-direction', 'none');
+        expect(getComputedStyle(element).overflowX).to.equal('hidden');
         expect(getComputedStyle(element).overflowY).to.equal('hidden');
       });
 


### PR DESCRIPTION
Based on API feedback it was decided to have a single attribute with
`horizontal`, `vertical`, `both` and `none` as possible values.
Defaults to `both`