### PR TITLE
Add explicit dependency to sinonjs with alternative repo

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,6 +40,7 @@
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
     "webcomponentsjs": "^1.0.0",
+    "sinonjs": "Polymer/sinon.js#^1.14.1",
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.0.0"
   },


### PR DESCRIPTION
Repository github.com/blittle/sinon.js was deleted
And bower install fails
Workaround for https://github.com/Polymer/tools/issues/3488
While https://github.com/Polymer/tools/pull/3489 isn't merged and released